### PR TITLE
Added call to 'destroy' method in knockout Select2 control

### DIFF
--- a/Controls/Select2/src/DotVVM.Contrib.Controls/Resources/DotvvmContrib-Select2.js
+++ b/Controls/Select2/src/DotVVM.Contrib.Controls/Resources/DotvvmContrib-Select2.js
@@ -10,6 +10,7 @@ ko.bindingHandlers["dotvvm-contrib-Select2"] = {
         dotvvm.events.afterPostback.subscribe(refreshHandler);
         ko.utils.domNodeDisposal.addDisposeCallback(element, function () {
             dotvvm.events.afterPostback.unsubscribe(refreshHandler);
+            $(element).select2('destroy');
         });
     }
 };


### PR DESCRIPTION
knockout needs to destroy the javascript/jquery controls instance you have created to prevent memory leaks in SPA.
