### PR TITLE
Added support for .NET Framework

### DIFF
--- a/Controls/BootstrapColorpicker/src/DotVVM.Contrib.BootstrapColorpicker/DotVVM.Contrib.BootstrapColorpicker.csproj
+++ b/Controls/BootstrapColorpicker/src/DotVVM.Contrib.BootstrapColorpicker/DotVVM.Contrib.BootstrapColorpicker.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
 	<PackageId>DotVVM.Contrib.BootstrapColorpicker</PackageId>
     <AssemblyName>DotVVM.Contrib.BootstrapColorpicker</AssemblyName>
     <Description>The BootstrapColorpicker control for DotVVM made by DotVVM Contrib community.</Description>

--- a/Controls/BootstrapDatepicker/src/DotVVM.Contrib.BootstrapDatepicker/DotVVM.Contrib.BootstrapDatepicker.csproj
+++ b/Controls/BootstrapDatepicker/src/DotVVM.Contrib.BootstrapDatepicker/DotVVM.Contrib.BootstrapDatepicker.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
 		<PackageId>DotVVM.Contrib.BootstrapDatepicker</PackageId>
 		<AssemblyName>DotVVM.Contrib.BootstrapDatepicker</AssemblyName>
 		<Description>The BootstrapDatepicker control for DotVVM made by DotVVM Contrib community.</Description>

--- a/Controls/CkEditorMinimal/src/DotVVM.Contrib.CkEditorMinimal/DotVVM.Contrib.CkEditorMinimal.csproj
+++ b/Controls/CkEditorMinimal/src/DotVVM.Contrib.CkEditorMinimal/DotVVM.Contrib.CkEditorMinimal.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
 		<PackageId>DotVVM.Contrib.CkEditorMinimal</PackageId>
 		<AssemblyName>DotVVM.Contrib.CkEditorMinimal</AssemblyName>
 		<Description>The CkEditorMinimal control for DotVVM made by DotVVM Contrib community.</Description>

--- a/Controls/CookieBar/src/DotVVM.Contrib.CookieBar/DotVVM.Contrib.CookieBar.csproj
+++ b/Controls/CookieBar/src/DotVVM.Contrib.CookieBar/DotVVM.Contrib.CookieBar.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
 		<PackageId>DotVVM.Contrib.CookieBar</PackageId>
 		<AssemblyName>DotVVM.Contrib.CookieBar</AssemblyName>
 		<Description>The CookieBar control for DotVVM made by DotVVM Contrib community.</Description>

--- a/Controls/EditableForm/src/DotVVM.Contrib.EditableForm/DotVVM.Contrib.EditableForm.csproj
+++ b/Controls/EditableForm/src/DotVVM.Contrib.EditableForm/DotVVM.Contrib.EditableForm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
 		<PackageId>DotVVM.Contrib.EditableForm</PackageId>
 		<RootNamespace>DotVVM.Contrib.EditableForm</RootNamespace>
 		<Description>The EditableForm control for DotVVM made by DotVVM Contrib community.</Description>

--- a/Controls/FAIcon/src/DotVVM.Contrib.FAIcon/DotVVM.Contrib.FAIcon.csproj
+++ b/Controls/FAIcon/src/DotVVM.Contrib.FAIcon/DotVVM.Contrib.FAIcon.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>netstandard2.1</TargetFrameworks>
+	  <TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
 	  <PackageId>DotVVM.Contrib.FAIcon</PackageId>
     <Authors>DotVVM Contrib</Authors>
     <Description>The FAIcon control for DotVVM made by DotVVM Contrib community.</Description>

--- a/Controls/GoogleAnalyticsJavascript/src/DotVVM.Contrib.GoogleAnalyticsJavascript/DotVVM.Contrib.GoogleAnalyticsJavascript.csproj
+++ b/Controls/GoogleAnalyticsJavascript/src/DotVVM.Contrib.GoogleAnalyticsJavascript/DotVVM.Contrib.GoogleAnalyticsJavascript.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
 		<PackageId>DotVVM.Contrib.GoogleAnalyticsJavascript</PackageId>
 		<AssemblyName>DotVVM.Contrib.GoogleAnalyticsJavascript</AssemblyName>
 		<Description>The GoogleAnalyticsJavascript control for DotVVM made by DotVVM Contrib community.</Description>

--- a/Controls/GoogleMap/src/DotVVM.Contrib.GoogleMap/DotVVM.Contrib.GoogleMap.csproj
+++ b/Controls/GoogleMap/src/DotVVM.Contrib.GoogleMap/DotVVM.Contrib.GoogleMap.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>netstandard2.1</TargetFrameworks>
+	  <TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
 	  <PackageId>DotVVM.Contrib.GoogleMap</PackageId>
 	  <AssemblyName>DotVVM.Contrib.GoogleMap</AssemblyName>
 	  <Description>The GoogleMap control for DotVVM made by DotVVM Contrib community.</Description>

--- a/Controls/LoadablePanel/src/DotVVM.Contrib.LoadablePanel/DotVVM.Contrib.LoadablePanel.csproj
+++ b/Controls/LoadablePanel/src/DotVVM.Contrib.LoadablePanel/DotVVM.Contrib.LoadablePanel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>netstandard2.1</TargetFrameworks>
+	  <TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
 	  <PackageId>DotVVM.Contrib.LoadablePanel</PackageId>
     <Description>The LoadablePanel control for DotVVM made by DotVVM Contrib community.</Description>
     <PackageTags>dotvvm;asp.net;mvvm;owin;dotnetcore;dnx</PackageTags>

--- a/Controls/MultilevelMenu/src/DotVVM.Contrib.MultilevelMenu/DotVVM.Contrib.MultilevelMenu.csproj
+++ b/Controls/MultilevelMenu/src/DotVVM.Contrib.MultilevelMenu/DotVVM.Contrib.MultilevelMenu.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
 		<PackageId>DotVVM.Contrib.MultilevelMenu</PackageId>
 		<Description>The MultilevelMenu control for DotVVM made by DotVVM Contrib community.</Description>
 		<AssemblyName>DotVVM.Contrib.MultilevelMenu</AssemblyName>

--- a/Controls/NoUiSlider/src/DotVVM.Contrib.NoUiSlider/DotVVM.Contrib.NoUiSlider.csproj
+++ b/Controls/NoUiSlider/src/DotVVM.Contrib.NoUiSlider/DotVVM.Contrib.NoUiSlider.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
 		<PackageId>DotVVM.Contrib.NoUiSlider</PackageId>
 		<Description>The Slider and Switch controls for DotVVM made by DotVVM Contrib community.</Description>
 		<PackageTags>dotvvm;asp.net;mvvm;owin;dotnetcore;dnx</PackageTags>

--- a/Controls/PolicyView/src/DotVVM.Contrib.PolicyView/DotVVM.Contrib.PolicyView.csproj
+++ b/Controls/PolicyView/src/DotVVM.Contrib.PolicyView/DotVVM.Contrib.PolicyView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>netstandard2.1</TargetFrameworks>
+	  <TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
 	  <PackageId>DotVVM.Contrib.PolicyView</PackageId>
     <Description>The PolicyView control for DotVVM made by DotVVM Contrib community.</Description>
     <PackageTags>dotvvm;asp.net;mvvm;owin;dotnetcore;dnx</PackageTags>

--- a/Controls/PolymorphTemplateSelector/src/DotVVM.Contrib.PolymorphTemplateSelector/DotVVM.Contrib.PolymorphTemplateSelector.csproj
+++ b/Controls/PolymorphTemplateSelector/src/DotVVM.Contrib.PolymorphTemplateSelector/DotVVM.Contrib.PolymorphTemplateSelector.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
 		<PackageId>DotVVM.Contrib.PolymorphTemplateSelector</PackageId>
 		<AssemblyName>DotVVM.Contrib.PolymorphTemplateSelector</AssemblyName>
 		<LangVersion>9.0</LangVersion>

--- a/Controls/QrCode/src/DotVVM.Contrib.QrCode/DotVVM.Contrib.QrCode.csproj
+++ b/Controls/QrCode/src/DotVVM.Contrib.QrCode/DotVVM.Contrib.QrCode.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
 		<PackageId>DotVVM.Contrib.QrCode</PackageId>
 		<AssemblyName>DotVVM.Contrib.QrCode</AssemblyName>
 		<Description>The QrCode control for DotVVM made by DotVVM Contrib community.</Description>

--- a/Controls/Select2/src/DotVVM.Contrib.Select2/DotVVM.Contrib.Select2.csproj
+++ b/Controls/Select2/src/DotVVM.Contrib.Select2/DotVVM.Contrib.Select2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
 		<PackageId>DotVVM.Contrib.Select2</PackageId>
 		<AssemblyName>DotVVM.Contrib.Select2</AssemblyName>
 		<Description>The Select2 control for DotVVM made by DotVVM Contrib community.</Description>

--- a/Controls/TemplateSelector/src/DotVVM.Contrib.TemplateSelector/DotVVM.Contrib.TemplateSelector.csproj
+++ b/Controls/TemplateSelector/src/DotVVM.Contrib.TemplateSelector/DotVVM.Contrib.TemplateSelector.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
 		<PackageId>DotVVM.Contrib.TemplateSelector</PackageId>
 		<AssemblyName>DotVVM.Contrib.TemplateSelector</AssemblyName>
 		<PackageVersion>2.4.0</PackageVersion>

--- a/Controls/TypeAhead/src/DotVVM.Contrib.TypeAhead/DotVVM.Contrib.TypeAhead.csproj
+++ b/Controls/TypeAhead/src/DotVVM.Contrib.TypeAhead/DotVVM.Contrib.TypeAhead.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
 		<LangVersion>9.0</LangVersion>
 		<PackageId>DotVVM.Contrib.TypeAhead</PackageId>
 		<AssemblyName>DotVVM.Contrib.TypeAhead</AssemblyName>

--- a/Controls/_template/src/DotVVM.Contrib.ControlName/DotVVM.Contrib.ControlName.csproj
+++ b/Controls/_template/src/DotVVM.Contrib.ControlName/DotVVM.Contrib.ControlName.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>netstandard2.1</TargetFrameworks>
+	  <TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
 	<PackageId>DotVVM.Contrib.ControlName</PackageId>
 	  <AssemblyName>DotVVM.Contrib.ControlName</AssemblyName>
 	  <Authors>DotVVM Contrib</Authors>


### PR DESCRIPTION
This PR adds back support for .NET Framework. Note that when targetting only `netstandard2.1` we are supporting only a subset of platforms supported by DotVVM Framework.