### PR TITLE
Set datacontext type to placeholder control

### DIFF
--- a/Controls/PolymorphTemplateSelector/src/DotVVM.Contrib.PolymorphTemplateSelector/PolymorphTemplateSelector.cs
+++ b/Controls/PolymorphTemplateSelector/src/DotVVM.Contrib.PolymorphTemplateSelector/PolymorphTemplateSelector.cs
@@ -109,6 +109,7 @@ namespace DotVVM.Contrib.PolymorphTemplateSelector
             {
                 var placeholder = new PlaceHolder();
                 placeholder.SetValue(Internal.PathFragmentProperty, template.GetValueBinding(DataContextProperty).GetKnockoutBindingExpression(this));
+                placeholder.SetDataContextType(template.GetDataContextType());
                 template.ContentTemplate.BuildContent(context, placeholder);
                 Children.Add(placeholder);
             }


### PR DESCRIPTION
Fix an issue of not being able to use DataContext binding inside of the PolymorphTemplate control.
Exception thrown:
DotVVM.Framework.Binding.BindingHelper+InvalidDataContextTypeExceptionCould not find DataContext space of '{value: Data}'. The DataContextType property of the binding does not correspond to DataContextType of the PlaceHolder nor any of its ancestors. Control's context is (type=DotVVM.Contrib.PolymorphTemplateSelector.Samples.Model.Sample4.PolyTop, par=[Sample4ViewModel]), binding's context is (type=DotVVM.Contrib.PolymorphTemplateSelector.Samples.Model.Sample4.Poly2, par=[PolyTop, Sample4ViewModel]). Real data context types: PolyTop, Sample4ViewModel.

[dotvvm-error-BindingHelper+InvalidDataContextTypeException.zip](https://github.com/riganti/dotvvm-contrib/files/11713019/dotvvm-error-BindingHelper%2BInvalidDataContextTypeException.zip)
